### PR TITLE
New dependency workflows

### DIFF
--- a/.github/workflows/dep-check.yml
+++ b/.github/workflows/dep-check.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: BigGeo-GIV/bg-ci
-        ref: workflow-testing
+        ref: main
         path: bg-ci
 
     - name: Install Python

--- a/.github/workflows/dep-update.yml
+++ b/.github/workflows/dep-update.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: BigGeo-GIV/bg-ci
-        ref: workflow-testing
+        ref: main
         path: bg-ci
 
     - name: Install Python

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,4 +1,4 @@
-name: Update Dependencies
+name: Check for Dependency Updates
 
 on:
   workflow_call:
@@ -11,7 +11,7 @@ on:
         required: true
 
 jobs:
-  update-deps:
+  check-deps:
     runs-on: ubuntu-latest
     env: {CONAN_REVISIONS_ENABLED: 1}
 
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-python@v4
       with: { python-version: "3.8" }
 
-    - name: Update dependencies
+    - name: Update dependencies script
       id: bump
       run: |
         pip3 install "conan<2"
@@ -45,19 +45,16 @@ jobs:
         echo "${body}" >> $GITHUB_OUTPUT
         echo "$EOF" >> $GITHUB_OUTPUT
 
-        myDate=$(date +'%Y-%m-%d')
-        echo "DATE=${myDate}" >> $GITHUB_OUTPUT
-
-    - name: Comment PR
+    - name: Comment on PR
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          Some dependencies in this branch are out of date:
+          Hi there, it looks like some dependencies in this branch are out of date.
 
           ${{ steps.bump.outputs.BODY}}
 
           If you would like me to update them, please add the "update dependencies" label to this PR.
-
+          If you don't plan on updating the dependencies, consider setting a specific version in the dependencies.json file.
         comment_tag: dependencies
     # - uses: peter-evans/create-pull-request@v5
     #   with:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: BigGeo-GIV/bg-ci
-        ref: main
+        ref: workflow-testing
         path: bg-ci
 
     - name: Install Python
@@ -39,7 +39,6 @@ jobs:
         conan remote add bg-conan ${{ secrets.JF_CONAN_URL }}
         conan user -p ${{ secrets.JF_ACCESS_TOKEN }} -r bg-conan github_workflow
 
-        python3 bg-ci/UpdateDeps.py bg-conan
         if body=$(python3 bg-ci/UpdateDeps.py bg-conan); then
           echo TRUE
           echo "GO=1" >> $GITHUB_OUTPUT
@@ -47,13 +46,10 @@ jobs:
           echo "BODY<<$EOF" >> $GITHUB_OUTPUT
           echo "${body}" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
-        else
-          echo ELSE
         fi
 
-
     - name: Comment on PR
-      if: steps.bump.outputs.GO == 1
+      if: steps.bump.outputs.GO
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -48,15 +48,15 @@ jobs:
         myDate=$(date +'%Y-%m-%d')
         echo "DATE=${myDate}" >> $GITHUB_OUTPUT
 
-    - name: Comment PR
-      uses: thollander/actions-comment-pull-request@v2
-      with:
-        message: |
-          Some dependencies in this branch are out of date:
+    # - name: Comment PR
+    #   uses: thollander/actions-comment-pull-request@v2
+    #   with:
+    #     message: |
+    #       Some dependencies in this branch are out of date:
 
-          ${{ steps.bump.outputs.BODY}}
+    #       ${{ steps.bump.outputs.BODY}}
 
-          If you would like me to update them, please add the <name> label to this PR.
+    #       If you would like me to update them, please add the <name> label to this PR.
 
     # - uses: peter-evans/create-pull-request@v5
     #   with:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -39,7 +39,9 @@ jobs:
         conan remote add bg-conan ${{ secrets.JF_CONAN_URL }}
         conan user -p ${{ secrets.JF_ACCESS_TOKEN }} -r bg-conan github_workflow
 
+        python3 bg-ci/UpdateDeps.py bg-conan
         if body=$(python3 bg-ci/UpdateDeps.py bg-conan); then
+          echo TRUE
           echo "GO=1" >> $GITHUB_OUTPUT
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "BODY<<$EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -48,34 +48,44 @@ jobs:
         myDate=$(date +'%Y-%m-%d')
         echo "DATE=${myDate}" >> $GITHUB_OUTPUT
 
-    - uses: peter-evans/create-pull-request@v5
+    - name: Comment PR
+      uses: thollander/actions-comment-pull-request@v2
       with:
-        add-paths: dependencies.json
-        commit-message: Update dependencies
-        committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-        author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-        signoff: false
-        branch: dependencies-${{ steps.bump.outputs.DATE }}
-        delete-branch: true
-        title: 'deps: Update dependencies ${{ steps.bump.outputs.DATE }}'
-        body: ${{ steps.bump.outputs.BODY }}
+        message: |
+          Some dependencies in this branch are out of date:
 
-    - name: Commit to trigger CI on PR
-      id: commit
-      env:
-        GH_TOKEN: ${{ secrets.GH_ACCESS }}
-      run: |
-        if $( git ls-remote --exit-code --heads origin dependencies-${{ steps.bump.outputs.DATE }} > /dev/null); then
-          echo "PUSH=1" >> $GITHUB_OUTPUT
-          git pull origin dependencies-${{ steps.bump.outputs.DATE }}
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git commit --allow-empty -m "Trigger CI"
-        fi
+          ${{ steps.bump.outputs.BODY}}
 
-    - name: Push changes
-      if: steps.commit.outputs.PUSH
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GH_ACCESS }}
-        branch: dependencies-${{ steps.bump.outputs.DATE }}
+          If you would like me to update them, please add the <name> label to this PR.
+
+    # - uses: peter-evans/create-pull-request@v5
+    #   with:
+    #     add-paths: dependencies.json
+    #     commit-message: Update dependencies
+    #     committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+    #     author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+    #     signoff: false
+    #     branch: dependencies-${{ steps.bump.outputs.DATE }}
+    #     delete-branch: true
+    #     title: 'deps: Update dependencies ${{ steps.bump.outputs.DATE }}'
+    #     body: ${{ steps.bump.outputs.BODY }}
+
+    # - name: Commit to trigger CI on PR
+    #   id: commit
+    #   env:
+    #     GH_TOKEN: ${{ secrets.GH_ACCESS }}
+    #   run: |
+    #     if $( git ls-remote --exit-code --heads origin dependencies-${{ steps.bump.outputs.DATE }} > /dev/null); then
+    #       echo "PUSH=1" >> $GITHUB_OUTPUT
+    #       git pull origin dependencies-${{ steps.bump.outputs.DATE }}
+    #       git config --local user.name "github-actions[bot]"
+    #       git config --local user.email "github-actions[bot]@users.noreply.github.com"
+    #       git commit --allow-empty -m "Trigger CI"
+    #     fi
+
+    # - name: Push changes
+    #   if: steps.commit.outputs.PUSH
+    #   uses: ad-m/github-push-action@master
+    #   with:
+    #     github_token: ${{ secrets.GH_ACCESS }}
+    #     branch: dependencies-${{ steps.bump.outputs.DATE }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -46,7 +46,6 @@ jobs:
           echo "${body}" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
         fi
-        echo $GO
 
     - name: Comment on PR
       if: steps.bump.outputs.GO == 1

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -48,15 +48,15 @@ jobs:
         myDate=$(date +'%Y-%m-%d')
         echo "DATE=${myDate}" >> $GITHUB_OUTPUT
 
-    # - name: Comment PR
-    #   uses: thollander/actions-comment-pull-request@v2
-    #   with:
-    #     message: |
-    #       Some dependencies in this branch are out of date:
+    - name: Comment PR
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: |
+          Some dependencies in this branch are out of date:
 
-    #       ${{ steps.bump.outputs.BODY}}
+          ${{ steps.bump.outputs.BODY}}
 
-    #       If you would like me to update them, please add the <name> label to this PR.
+          If you would like me to update them, please add the <name> label to this PR.
 
     # - uses: peter-evans/create-pull-request@v5
     #   with:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -46,6 +46,7 @@ jobs:
           echo "${body}" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
         fi
+        echo $GO
 
     - name: Comment on PR
       if: steps.bump.outputs.GO
@@ -56,6 +57,6 @@ jobs:
 
           ${{ steps.bump.outputs.BODY}}
 
-          If you would like me to update them, please add the "update dependencies" label to this PR.
+          If you would like me to update them, please add the "update dependencies" label to this PR.\
           If you don't plan on updating the dependencies, consider setting a specific version in the dependencies.json file.
         comment_tag: dependencies

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -39,13 +39,16 @@ jobs:
         conan remote add bg-conan ${{ secrets.JF_CONAN_URL }}
         conan user -p ${{ secrets.JF_ACCESS_TOKEN }} -r bg-conan github_workflow
 
-        body=$(python3 bg-ci/UpdateDeps.py bg-conan)
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        echo "BODY<<$EOF" >> $GITHUB_OUTPUT
-        echo "${body}" >> $GITHUB_OUTPUT
-        echo "$EOF" >> $GITHUB_OUTPUT
+        if body=$(python3 bg-ci/UpdateDeps.py bg-conan); then
+          echo "GO=1" >> $GITHUB_OUTPUT
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "BODY<<$EOF" >> $GITHUB_OUTPUT
+          echo "${body}" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+        fi
 
     - name: Comment on PR
+      if: steps.bump.outputs.GO
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
@@ -56,34 +59,3 @@ jobs:
           If you would like me to update them, please add the "update dependencies" label to this PR.
           If you don't plan on updating the dependencies, consider setting a specific version in the dependencies.json file.
         comment_tag: dependencies
-    # - uses: peter-evans/create-pull-request@v5
-    #   with:
-    #     add-paths: dependencies.json
-    #     commit-message: Update dependencies
-    #     committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-    #     author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-    #     signoff: false
-    #     branch: dependencies-${{ steps.bump.outputs.DATE }}
-    #     delete-branch: true
-    #     title: 'deps: Update dependencies ${{ steps.bump.outputs.DATE }}'
-    #     body: ${{ steps.bump.outputs.BODY }}
-
-    # - name: Commit to trigger CI on PR
-    #   id: commit
-    #   env:
-    #     GH_TOKEN: ${{ secrets.GH_ACCESS }}
-    #   run: |
-    #     if $( git ls-remote --exit-code --heads origin dependencies-${{ steps.bump.outputs.DATE }} > /dev/null); then
-    #       echo "PUSH=1" >> $GITHUB_OUTPUT
-    #       git pull origin dependencies-${{ steps.bump.outputs.DATE }}
-    #       git config --local user.name "github-actions[bot]"
-    #       git config --local user.email "github-actions[bot]@users.noreply.github.com"
-    #       git commit --allow-empty -m "Trigger CI"
-    #     fi
-
-    # - name: Push changes
-    #   if: steps.commit.outputs.PUSH
-    #   uses: ad-m/github-push-action@master
-    #   with:
-    #     github_token: ${{ secrets.GH_ACCESS }}
-    #     branch: dependencies-${{ steps.bump.outputs.DATE }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -45,7 +45,10 @@ jobs:
           echo "BODY<<$EOF" >> $GITHUB_OUTPUT
           echo "${body}" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
+        else
+          echo ELSE
         fi
+
 
     - name: Comment on PR
       if: steps.bump.outputs.GO == 1

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -49,7 +49,7 @@ jobs:
         echo $GO
 
     - name: Comment on PR
-      if: steps.bump.outputs.GO
+      if: steps.bump.outputs.GO == 1
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: BigGeo-GIV/bg-ci
-        ref: main
+        ref: workflow-testing
         path: bg-ci
 
     - name: Install Python
@@ -50,7 +50,7 @@ jobs:
         fi
 
     - name: Commit and push updates
-      if: steps.bump.outputs.GO == 1
+      if: steps.bump.outputs.GO
       id: commit
       env:
         GH_TOKEN: ${{ secrets.GH_ACCESS }}

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -86,4 +86,5 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GH_ACCESS }}
-        branch: ${{ github.ref }}
+        repository: ${{ github.repository }}
+        branch: ${{ github.head_ref }}

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -30,17 +30,16 @@ jobs:
       uses: actions/setup-python@v4
       with: { python-version: "3.8" }
 
-    - name: Git setup
-      id: setup-git
-      env:
-        GH_TOKEN: ${{ secrets.GH_ACCESS }}
-      run: |
-        git config --local user.name "github-actions[bot]"
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        git add dependencies.json
-        git remote add head ${{ github.repositoryUrl }}
-        git fetch head
-        git checkout ${{ github.head_ref }}
+    # - name: Git setup
+    #   id: setup-git
+    #   env:
+    #     GH_TOKEN: ${{ secrets.GH_ACCESS }}
+    #   run: |
+    #     git config --local user.name "github-actions[bot]"
+    #     git config --local user.email "github-actions[bot]@users.noreply.github.com"
+    #     git remote add head ${{ github.repositoryUrl }}
+    #     git fetch head
+    #     git checkout ${{ github.head_ref }}
 
     - name: Update dependencies
       id: bump
@@ -88,14 +87,10 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_ACCESS }}
       run: |
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git add dependencies.json
         git commit -m "Update dependencies"
-        git push
 
-
-    # - name: Push changes
-    #   uses: ad-m/github-push-action@master
-    #   with:
-    #     github_token: ${{ secrets.GH_ACCESS }}
-    #     repository: ${{ github.repository }}
-    #     branch: ${{ github.head_ref }}
+    - name: Push changes
+      uses: ad-m/github-push-action@master

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -30,6 +30,18 @@ jobs:
       uses: actions/setup-python@v4
       with: { python-version: "3.8" }
 
+    - name: Git setup
+      id: setup-git
+      env:
+        GH_TOKEN: ${{ secrets.GH_ACCESS }}
+      run: |
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git add dependencies.json
+        git remote add head ${{ github.repositoryUrl }}
+        git fetch head
+        git checkout ${{ github.head_ref }}
+
     - name: Update dependencies
       id: bump
       run: |
@@ -76,15 +88,14 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_ACCESS }}
       run: |
-        git config --local user.name "github-actions[bot]"
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git add dependencies.json
         git commit -m "Update dependencies"
+        git push
 
 
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GH_ACCESS }}
-        repository: ${{ github.repository }}
-        branch: ${{ github.head_ref }}
+    # - name: Push changes
+    #   uses: ad-m/github-push-action@master
+    #   with:
+    #     github_token: ${{ secrets.GH_ACCESS }}
+    #     repository: ${{ github.repository }}
+    #     branch: ${{ github.head_ref }}

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GH_ACCESS }}
 
     - uses: actions/checkout@v3
       with:
@@ -91,7 +89,7 @@ jobs:
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git add dependencies.json
         git commit -m "Update dependencies"
-        git pull
+        git push
 
-    - name: Push changes
-      uses: ad-m/github-push-action@master
+    # - name: Push changes
+    #   uses: ad-m/github-push-action@master

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -48,17 +48,17 @@ jobs:
         myDate=$(date +'%Y-%m-%d')
         echo "DATE=${myDate}" >> $GITHUB_OUTPUT
 
-    - name: Comment PR
-      uses: thollander/actions-comment-pull-request@v2
-      with:
-        message: |
-          Some dependencies in this branch are out of date:
+    # - name: Comment PR
+    #   uses: thollander/actions-comment-pull-request@v2
+    #   with:
+    #     message: |
+    #       Some dependencies in this branch are out of date:
 
-          ${{ steps.bump.outputs.BODY}}
+    #       ${{ steps.bump.outputs.BODY}}
 
-          If you would like me to update them, please add the "update dependencies" label to this PR.
+    #       If you would like me to update them, please add the "update dependencies" label to this PR.
 
-        comment_tag: dependencies
+    #     comment_tag: dependencies
     # - uses: peter-evans/create-pull-request@v5
     #   with:
     #     add-paths: dependencies.json
@@ -71,22 +71,19 @@ jobs:
     #     title: 'deps: Update dependencies ${{ steps.bump.outputs.DATE }}'
     #     body: ${{ steps.bump.outputs.BODY }}
 
-    # - name: Commit to trigger CI on PR
-    #   id: commit
-    #   env:
-    #     GH_TOKEN: ${{ secrets.GH_ACCESS }}
-    #   run: |
-    #     if $( git ls-remote --exit-code --heads origin dependencies-${{ steps.bump.outputs.DATE }} > /dev/null); then
-    #       echo "PUSH=1" >> $GITHUB_OUTPUT
-    #       git pull origin dependencies-${{ steps.bump.outputs.DATE }}
-    #       git config --local user.name "github-actions[bot]"
-    #       git config --local user.email "github-actions[bot]@users.noreply.github.com"
-    #       git commit --allow-empty -m "Trigger CI"
-    #     fi
+    - name: Commit to trigger CI on PR
+      id: commit
+      env:
+        GH_TOKEN: ${{ secrets.GH_ACCESS }}
+      run: |
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git add dependencies.json
+        git commit -m "Update dependencies"
 
-    # - name: Push changes
-    #   if: steps.commit.outputs.PUSH
-    #   uses: ad-m/github-push-action@master
-    #   with:
-    #     github_token: ${{ secrets.GH_ACCESS }}
-    #     branch: dependencies-${{ steps.bump.outputs.DATE }}
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GH_ACCESS }}
+        branch: ${{ github.ref }}

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        token: ${{ secrets.GH_ACCESS }}
+        repository: ${{ github.repository }}
+        ref: ${{ github.head_ref }}
 
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -32,18 +32,7 @@ jobs:
       uses: actions/setup-python@v4
       with: { python-version: "3.8" }
 
-    # - name: Git setup
-    #   id: setup-git
-    #   env:
-    #     GH_TOKEN: ${{ secrets.GH_ACCESS }}
-    #   run: |
-    #     git config --local user.name "github-actions[bot]"
-    #     git config --local user.email "github-actions[bot]@users.noreply.github.com"
-    #     git remote add head ${{ github.repositoryUrl }}
-    #     git fetch head
-    #     git checkout ${{ github.head_ref }}
-
-    - name: Update dependencies
+    - name: Update dependencies script
       id: bump
       run: |
         pip3 install "conan<2"
@@ -52,39 +41,16 @@ jobs:
         conan remote add bg-conan ${{ secrets.JF_CONAN_URL }}
         conan user -p ${{ secrets.JF_ACCESS_TOKEN }} -r bg-conan github_workflow
 
-        body=$(python3 bg-ci/UpdateDeps.py bg-conan)
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        echo "BODY<<$EOF" >> $GITHUB_OUTPUT
-        echo "${body}" >> $GITHUB_OUTPUT
-        echo "$EOF" >> $GITHUB_OUTPUT
+        if body=$(python3 bg-ci/UpdateDeps.py bg-conan); then
+          echo "GO=1" >> $GITHUB_OUTPUT
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "BODY<<$EOF" >> $GITHUB_OUTPUT
+          echo "${body}" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+        fi
 
-        myDate=$(date +'%Y-%m-%d')
-        echo "DATE=${myDate}" >> $GITHUB_OUTPUT
-
-    # - name: Comment PR
-    #   uses: thollander/actions-comment-pull-request@v2
-    #   with:
-    #     message: |
-    #       Some dependencies in this branch are out of date:
-
-    #       ${{ steps.bump.outputs.BODY}}
-
-    #       If you would like me to update them, please add the "update dependencies" label to this PR.
-
-    #     comment_tag: dependencies
-    # - uses: peter-evans/create-pull-request@v5
-    #   with:
-    #     add-paths: dependencies.json
-    #     commit-message: Update dependencies
-    #     committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-    #     author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-    #     signoff: false
-    #     branch: dependencies-${{ steps.bump.outputs.DATE }}
-    #     delete-branch: true
-    #     title: 'deps: Update dependencies ${{ steps.bump.outputs.DATE }}'
-    #     body: ${{ steps.bump.outputs.BODY }}
-
-    - name: Commit to trigger CI on PR
+    - name: Commit and push updates
+      if: steps.bump.outputs.GO
       id: commit
       env:
         GH_TOKEN: ${{ secrets.GH_ACCESS }}

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -91,6 +91,7 @@ jobs:
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git add dependencies.json
         git commit -m "Update dependencies"
+        git pull
 
     - name: Push changes
       uses: ad-m/github-push-action@master

--- a/.github/workflows/dependencies2.yml
+++ b/.github/workflows/dependencies2.yml
@@ -50,7 +50,7 @@ jobs:
         fi
 
     - name: Commit and push updates
-      if: steps.bump.outputs.GO
+      if: steps.bump.outputs.GO == 1
       id: commit
       env:
         GH_TOKEN: ${{ secrets.GH_ACCESS }}
@@ -60,6 +60,3 @@ jobs:
         git add dependencies.json
         git commit -m "Update dependencies"
         git push
-
-    # - name: Push changes
-    #   uses: ad-m/github-push-action@master

--- a/UpdateDeps.py
+++ b/UpdateDeps.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
                 pass
 
     if len(newDeps) == 0:
-        exit(0)
+        exit(1)
 
     for n, v in newDeps.items():
         cur = deps[n]["current"]

--- a/UpdateDeps.py
+++ b/UpdateDeps.py
@@ -26,15 +26,12 @@ if __name__ == "__main__":
                 pass
 
     if len(newDeps) == 0:
-        print("I must die")
         exit(1)
 
     for n, v in newDeps.items():
         cur = deps[n]["current"]
         deps[n]["current"] = v
         print(f"{n}: {cur} -> {v}")
-    print("I didn't die?")
-
 
     json_object = json.dumps(deps, indent=4) + "\n"
     open("dependencies.json", "w").write(json_object)

--- a/UpdateDeps.py
+++ b/UpdateDeps.py
@@ -26,12 +26,15 @@ if __name__ == "__main__":
                 pass
 
     if len(newDeps) == 0:
+        print("I must die")
         exit(1)
 
     for n, v in newDeps.items():
         cur = deps[n]["current"]
         deps[n]["current"] = v
         print(f"{n}: {cur} -> {v}")
+    print("I didn't die?")
+
 
     json_object = json.dumps(deps, indent=4) + "\n"
     open("dependencies.json", "w").write(json_object)


### PR DESCRIPTION
Instead of pushing PRs with dependency updates, the bot will now look at newly created PRs for out of date dependencies. If so, it will leave a comment explaining which dependencies are out of data and that they can be automagically updated by adding the "update dependencies" label to the PR. 