### PR TITLE
Only run conan upload on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,8 @@ jobs:
 
     - name: Upload to conan
       shell: bash
-      if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+      if: matrix.os == 'ubuntu-22.04'
+        && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
         && github.event_name == 'push'
         && inputs.conan_create
       run: |


### PR DESCRIPTION
Conan upload doesn't work on Windows and isn't necessarily useful anyway so disable it. 