### PR TITLE
Update to Ubuntu 24.04 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       incs:  ${{ steps.matrix.outputs.incs }}
       comps: ${{ steps.matrix.outputs.comps }}
@@ -71,7 +71,7 @@ jobs:
       run: |
         if [[ '${{ steps.which.outputs.extended }}' == 'true' ]]; then
           comps='[["gcc", 13], ["gcc", 14], ["clang", 17], ["clang", 18]]'
-          incs='[ {"os": "ubuntu-22.04", "comp": ["gcc", 13]}'
+          incs='[ {"os": "ubuntu-24.04", "comp": ["gcc", 13]}'
           if [[ '${{inputs.windows}}' == 'true' ]]; then
             incs="$incs, {\"os\": \"windows-2022\"}"
           fi
@@ -84,7 +84,7 @@ jobs:
           echo "incs=${incs}" >> "$GITHUB_OUTPUT"
         else
           comps='[["clang", 18]]'
-          incs='[ {"os": "ubuntu-22.04", "comp": ["gcc", 13]}'
+          incs='[ {"os": "ubuntu-24.04", "comp": ["gcc", 13]}'
           if [[ '${{inputs.windows}}' == 'true' ]]; then
             incs="$incs, {\"os\": \"windows-2022\"}"
           fi

--- a/.github/workflows/conan-dev.yml
+++ b/.github/workflows/conan-dev.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   ubunutu-gcc:
     env: {CONAN_REVISIONS_ENABLED: 1}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with: { submodules: recursive }
@@ -35,7 +35,7 @@ jobs:
 
   ubunutu-clang:
     env: {CONAN_REVISIONS_ENABLED: 1}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with: { submodules: recursive }


### PR DESCRIPTION
This gives access to newer compilers used on distros such as fedora, and allows us to test against more recent versions of gcc and clang in CI