### PR TITLE
feat: Add the ability to cache duckdb when building earthquack on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,20 +215,21 @@ jobs:
           build/src/
           build/third_party/
           build/tools/
+          build/test/
           build/extension/core_functions/
           build/extension/jemalloc/
           build/extension/parquet/
         key: duckdb-build-${{ runner.os }}-${{ matrix.comp[0] }}-${{ matrix.comp[1] }}-${{ steps.duckdb-sha.outputs.sha }}
-
-    - name: Restore cache timestamps
-      if: inputs.cache_duckdb && steps.duckdb-cache.outputs.cache-hit == 'true'
-      run: find build/ -exec touch {} +
 
     - name: Configure
       shell: bash
       run: |
         osAry=($(echo ${{ matrix.os }} | tr "-" "\n")) && os=${osAry[0]}
         invoke config --no-ninja --preset "ci-${os}"
+
+    - name: Restore cache timestamps
+      if: inputs.cache_duckdb && steps.duckdb-cache.outputs.cache-hit == 'true'
+      run: find build/ -exec touch {} +
 
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ on:
         required: false
         default: true
         type: boolean
+      cache_duckdb: 
+        required: false
+        default: false
+        type: boolean
     secrets:
       GH_ACCESS:
         required: true
@@ -197,6 +201,17 @@ jobs:
         verAry=($(conan inspect . | grep version | tr ":" "\n")) && ver=${verAry[1]}
         nameVer=$(echo ${name}/${ver})
         conan upload ${nameVer} -r bg-conan -c
+
+    - name: Get DuckDB commit hash
+      id: duckdb-sha
+      if: inputs.cache_duckdb
+      run: echo "sha=$(git -C duckdb rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v4
+      if: inputs.cache_duckdb
+      with:                                                                                             
+        path: build/
+        key: duckdb-build-${{ runner.os }}-${{ matrix.comp[0] }}-${{ matrix.comp[1] }}-${{steps.duckdb-sha.outputs.sha }}
 
     - name: Configure
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
         required: false
         default: true
         type: boolean
-      cache_duckdb: 
+      cache_duckdb:
         required: false
         default: false
         type: boolean
@@ -209,9 +209,15 @@ jobs:
 
     - uses: actions/cache@v4
       if: inputs.cache_duckdb
-      with:                                                                                             
-        path: build/
-        key: duckdb-build-${{ runner.os }}-${{ matrix.comp[0] }}-${{ matrix.comp[1] }}-${{steps.duckdb-sha.outputs.sha }}
+      with:
+        path: |
+          build/src/
+          build/third_party/
+          build/tools/
+          build/extension/core_functions/
+          build/extension/jemalloc/
+          build/extension/parquet/
+        key: duckdb-build-${{ runner.os }}-${{ matrix.comp[0] }}-${{ matrix.comp[1] }}-${{ steps.duckdb-sha.outputs.sha }}
 
     - name: Configure
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,7 @@ jobs:
 
     - uses: actions/cache@v4
       if: inputs.cache_duckdb
+      id: duckdb-cache
       with:
         path: |
           build/src/
@@ -218,6 +219,10 @@ jobs:
           build/extension/jemalloc/
           build/extension/parquet/
         key: duckdb-build-${{ runner.os }}-${{ matrix.comp[0] }}-${{ matrix.comp[1] }}-${{ steps.duckdb-sha.outputs.sha }}
+
+    - name: Restore cache timestamps
+      if: inputs.cache_duckdb && steps.duckdb-cache.outputs.cache-hit == 'true'
+      run: find build/ -exec touch {} +
 
     - name: Configure
       shell: bash


### PR DESCRIPTION
This resolves the commit that the duckdb submodule points to, and caches the build. This should make earthquack CI much faster.

Fixes CORE-2010.