### PR TITLE
feat: Allow lint to be called outside of the main CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     uses: BigGeo-GIV/bg-ci/.github/workflows/lint.yml@v4.x
     secrets: inherit
 
-  matrix:
+  build-matrix:
     runs-on: ubuntu-24.04
     outputs:
       incs:  ${{ steps.matrix.outputs.incs }}
@@ -102,14 +102,14 @@ jobs:
 
   build-and-test:
     # Run build-and-test only when lint succeed
-    needs: [lint, matrix]
+    needs: [lint, build-matrix]
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        comp: ${{ fromJson(needs.matrix.outputs.comps) }}
-        include: ${{ fromJson(needs.matrix.outputs.incs) }}
+        comp: ${{ fromJson(needs.build-matrix.outputs.comps) }}
+        include: ${{ fromJson(needs.build-matrix.outputs.incs) }}
 
     runs-on: ${{ matrix.os }}
 
@@ -213,7 +213,7 @@ jobs:
     - name: Tests
       if: matrix.comp[0] == 'clang' && matrix.comp[1] == '18'
       run: |
-        if [[ '${{ needs.matrix.outputs.extended }}' == 'true' ]]; then
+        if [[ '${{ needs.build-matrix.outputs.extended }}' == 'true' ]]; then
           invoke test --extended
         else
           invoke test
@@ -221,7 +221,7 @@ jobs:
 
   build-python:
     # Run build python only when lint succeed
-    needs: [lint, matrix]
+    needs: [lint, build-matrix]
     if: inputs.build_python
 
     strategy:
@@ -229,7 +229,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         comp: [["clang", 18]]
-        include: ${{ fromJson(needs.matrix.outputs.incs) }}
+        include: ${{ fromJson(needs.build-matrix.outputs.incs) }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ concurrency:
 
 jobs:
   lint:
+    uses: BigGeo-GIV/bg-ci/.github/workflows/lint.yml@v4.x
+    secrets: inherit
+
+  matrix:
     runs-on: ubuntu-24.04
     outputs:
       incs:  ${{ steps.matrix.outputs.incs }}
@@ -44,13 +48,6 @@ jobs:
       extended: ${{ steps.which.outputs.extended }}
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.head_ref }}
-        token: ${{ secrets.GH_ACCESS }}
-        submodules: recursive
-
     - id: which
       env:
         NUMBER:  ${{ github.event.pull_request.number }}
@@ -103,40 +100,16 @@ jobs:
           echo ${incs}
         fi
 
-    - uses: actions/setup-python@v4
-      with: { python-version: "3.10" }
-
-    - name: Install clang-format
-      run: pip3 install clang-format==17.0.2
-
-    - name: clang-format
-      run: cmake -D FORMAT_COMMAND=clang-format -D FIX=YES -P cmake/lint.cmake
-
-    - name: Commit and push format
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: github.event_name == 'pull_request'
-      run: |
-        git config --local user.name "github-actions[bot]"
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        if [[ `git status --porcelain` ]]; then
-          echo "Changes detected. Pushing to github."
-          git commit -am "fixing format"
-          git push
-        else
-          echo "No changes were detected."
-        fi
-
   build-and-test:
     # Run build-and-test only when lint succeed
-    needs: [lint]
+    needs: [lint, matrix]
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        comp: ${{ fromJson(needs.lint.outputs.comps) }}
-        include: ${{ fromJson(needs.lint.outputs.incs) }}
+        comp: ${{ fromJson(needs.matrix.outputs.comps) }}
+        include: ${{ fromJson(needs.matrix.outputs.incs) }}
 
     runs-on: ${{ matrix.os }}
 
@@ -240,7 +213,7 @@ jobs:
     - name: Tests
       if: matrix.comp[0] == 'clang' && matrix.comp[1] == '18'
       run: |
-        if [[ '${{ needs.lint.outputs.extended }}' == 'true' ]]; then
+        if [[ '${{ needs.matrix.outputs.extended }}' == 'true' ]]; then
           invoke test --extended
         else
           invoke test
@@ -248,7 +221,7 @@ jobs:
 
   build-python:
     # Run build python only when lint succeed
-    needs: [lint]
+    needs: [lint, matrix]
     if: inputs.build_python
 
     strategy:
@@ -256,7 +229,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         comp: [["clang", 18]]
-        include: ${{ fromJson(needs.lint.outputs.incs) }}
+        include: ${{ fromJson(needs.matrix.outputs.incs) }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,43 @@
+name: Lint
+
+on:
+  workflow_call:
+    secrets:
+      GH_ACCESS:
+        required: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.head_ref }}
+        token: ${{ secrets.GH_ACCESS }}
+        submodules: recursive
+
+    - uses: actions/setup-python@v4
+      with: { python-version: "3.10" }
+
+    - name: Install clang-format
+      run: pip3 install clang-format==21.1.8
+
+    - name: clang-format
+      run: cmake -D FORMAT_COMMAND=clang-format -D FIX=YES -P cmake/lint.cmake
+
+    - name: Commit and push format
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: github.event_name == 'pull_request'
+      run: |
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        if [[ `git status --porcelain` ]]; then
+          echo "Changes detected. Pushing to github."
+          git commit -am "fixing format"
+          git push
+        else
+          echo "No changes were detected."
+        fi


### PR DESCRIPTION
This is useful for bg-tiff, because the build is nix/docker based, but I still want to lint code on CI. I have also updated clang-format to a newer version.

See here for an example of using this functionality: https://github.com/BigGeo-GIV/BG-TIFF/pull/38